### PR TITLE
API設計のリファクタリング

### DIFF
--- a/src/main/java/com/example/demo/controller/TodoController.java
+++ b/src/main/java/com/example/demo/controller/TodoController.java
@@ -5,6 +5,7 @@ import com.example.demo.entity.Todo;
 import com.example.demo.entity.UpdateTodo;
 import com.example.demo.service.TodoService;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -60,9 +61,11 @@ public class TodoController {
   }
 
   @PostMapping("/todos")
-  public String create(@RequestBody CreateTodo createTodo) {
+  public ResponseEntity<Map<String, String>> create(@RequestBody CreateTodo createTodo) {
     int createdNumber = todoService.create(createTodo);
-    return createdNumber + "件が正常に投稿されました！";
+    Map<String, String> message = new HashMap<String, String>();
+    message.put("message", createdNumber + "件が正常に作成されました");
+    return new ResponseEntity(message, HttpStatus.CREATED);
   }
 
   @PatchMapping("/todos/{id}")

--- a/src/main/java/com/example/demo/controller/TodoController.java
+++ b/src/main/java/com/example/demo/controller/TodoController.java
@@ -66,9 +66,12 @@ public class TodoController {
   }
 
   @PatchMapping("/todos/{id}")
-  public String update(@PathVariable int id, @RequestBody UpdateTodo updateTodo) {
+  public ResponseEntity<Map<String, String>> update(@PathVariable int id,
+                                                    @RequestBody UpdateTodo updateTodo) {
     int updatedNumber = todoService.update(id, updateTodo.getTitle(), updateTodo.getDescription());
-    return updatedNumber + "件が正常に更新されました！";
+    Map<String, String> message = new HashMap<String, String>();
+    message.put("message", updatedNumber + "件が正常に更新されました");
+    return new ResponseEntity(message, HttpStatus.NO_CONTENT);
   }
 
   @DeleteMapping("/todos/{id}")

--- a/src/main/java/com/example/demo/controller/TodoController.java
+++ b/src/main/java/com/example/demo/controller/TodoController.java
@@ -71,10 +71,8 @@ public class TodoController {
   @PatchMapping("/todos/{id}")
   public ResponseEntity<Map<String, String>> update(@PathVariable int id,
                                                     @RequestBody UpdateTodo updateTodo) {
-    int updatedNumber = todoService.update(id, updateTodo.getTitle(), updateTodo.getDescription());
-    Map<String, String> message = new HashMap<String, String>();
-    message.put("message", updatedNumber + "件が正常に更新されました");
-    return new ResponseEntity(message, HttpStatus.NO_CONTENT);
+    todoService.update(id, updateTodo.getTitle(), updateTodo.getDescription());
+    return new ResponseEntity(HttpStatus.NO_CONTENT);
   }
 
   @DeleteMapping("/todos/{id}")

--- a/src/main/java/com/example/demo/controller/TodoController.java
+++ b/src/main/java/com/example/demo/controller/TodoController.java
@@ -78,9 +78,11 @@ public class TodoController {
   }
 
   @DeleteMapping("/todos/{id}")
-  public String delete(@PathVariable int id) {
+  public ResponseEntity<Map<String, String>> delete(@PathVariable int id) {
     int deletedNumber = todoService.deleteTodo(id);
-    return deletedNumber + "件が正常に削除されました！";
+    Map<String, String> message = new HashMap<String, String>();
+    message.put("message", deletedNumber + "件が正常に削除されました");
+    return new ResponseEntity(message, HttpStatus.OK);
   }
 
   @ExceptionHandler(value = ResourceNotFoundException.class)


### PR DESCRIPTION
## issue
#16 API設計のリファクタリング

## 変更の概要
レスポンスをテキストで返したいたところをjson形式で返却するように変更。

## なぜこの変更をするのか
なぜjson形式で返したほうがいいのかがよくわかりませんでした。
[こちらの記事](https://developer.ntt.com/ja/blog/%E9%81%A9%E5%88%87%E3%81%AAAPI%E3%82%92%E8%A8%AD%E8%A8%88%E3%81%99%E3%82%8B%E3%81%9F%E3%82%81%E3%81%AB%E6%B3%A8%E6%84%8F%E3%81%97%E3%81%9F%E3%81%84%E3%81%93%E3%81%A8%E3%80%8C%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%95%E3%82%A7%E3%83%BC%E3%82%B9%E3%80%8D)をを見ると流行だからなのかなと。
![CleanShot 2022-10-06 at 16 39 42](https://user-images.githubusercontent.com/76928095/194246649-912a0e9e-ed4d-4974-9687-f5f45caadebe.png)

あとは、フロント側でjson形式でデータを受け取れれば扱いやすいからなのかなと考えました。
今回はメッセージだけですが、加工したデータをjson形式で渡す場合など。

## 変更内容
### POST
![CleanShot 2022-10-06 at 16 43 04](https://user-images.githubusercontent.com/76928095/194247341-0559dc9a-2035-433e-b340-1afff61616ad.png)

### PATCH
![CleanShot 2022-10-06 at 16 44 14](https://user-images.githubusercontent.com/76928095/194247576-7529dad0-b13b-48c6-968c-a12b1ee85dbe.png)


### DELETE
![CleanShot 2022-10-06 at 16 45 02](https://user-images.githubusercontent.com/76928095/194247749-e1c37f37-b6af-404d-8049-25e162c2b4ce.png)





